### PR TITLE
#141 Use standard macOS quit shortcut

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -84,7 +84,7 @@ export default class MenuBuilder {
         { type: 'separator' },
         {
           label: 'Quit',
-          accelerator: 'Command+Alt+Q',
+          accelerator: 'Command+Q',
           click: () => {
             app.quit();
           }


### PR DESCRIPTION
On macOS, the shortcut to quit apps is CMD+Q. CMD+ALT+Q is actually unexpected to macOS users.

Fixes #141