### PR TITLE
Don't show drop hint on same device

### DIFF
--- a/app/containers/HomePage/components/FileExplorer.jsx
+++ b/app/containers/HomePage/components/FileExplorer.jsx
@@ -1451,9 +1451,6 @@ class FileExplorer extends Component {
   _handleFilesDragOver = (e, { destinationDeviceType }) => {
     const { filesDrag } = this.props;
 
-    e.preventDefault();
-    e.stopPropagation();
-
     if (destinationDeviceType === filesDrag.sourceDeviceType) {
       if (filesDrag.sameSourceDestinationLock) {
         return null;
@@ -1470,6 +1467,11 @@ class FileExplorer extends Component {
 
       return null;
     }
+
+    /* Beyond this point we want to allow dropping */
+    /* so prevent the default behavior */
+    e.preventDefault();
+    e.stopPropagation();
 
     if (filesDrag.lock) {
       return null;


### PR DESCRIPTION
Changes where we prevent the default behavior to hint that dropping is not allowed on the same side of the transfer window.

This doesn't actually result in any behavior change (you couldn't drop to/from the same device before) but it no longer shows the "+" icon while dragging on the same side of the screen.

https://user-images.githubusercontent.com/484512/200223711-73e872a3-0bb9-468b-ad43-7f19d0539386.mov

This is a _slight_ improvement to https://github.com/ganeshrvel/openmtp/issues/265 until Move supported is added.