### PR TITLE
Add ability to update on quit

### DIFF
--- a/app/classes/AppUpdate.js
+++ b/app/classes/AppUpdate.js
@@ -100,6 +100,7 @@ export default class AppUpdate {
 
     this.autoUpdater.autoDownload = autoUpdateCheck && autoDownload;
     this.autoUpdater.allowPrerelease = allowPrerelease;
+    this.autoUpdater.autoInstallOnAppQuit = true;
     this.autoUpdateCheck = autoUpdateCheck;
 
     this.progressbarWindowDomReadyFlag = null;
@@ -220,14 +221,17 @@ export default class AppUpdate {
 
         const { response: buttonIndex } = await dialog.showMessageBox({
           title: 'Install Updates',
-          message: 'Updates downloaded. Application will quit now...',
-          buttons: ['Install and Relaunch'],
+          message: 'Updates downloaded. Install and relaunch?',
+          buttons: ['Install Now', 'Install on Quit'],
         });
 
         switch (buttonIndex) {
           case 0:
-          default:
             this.autoUpdater.quitAndInstall();
+            break;
+          case 1:
+          default:
+            // autoInstallOnAppQuit will trigger the update later
             break;
         }
       });


### PR DESCRIPTION
Instead of forcing the app to restart immediately after downloading an update, this enables updating-on-quit by adding a second button to the update available popup.

**Note that I was not able to test this very well, since I'm unable to package the app locally for some reason.**

Fixes #386