### PR TITLE
Add folder size calculation and display

### DIFF
--- a/app/containers/HomePage/components/FileExplorer.jsx
+++ b/app/containers/HomePage/components/FileExplorer.jsx
@@ -95,7 +95,7 @@ import {
   redditShareUrl,
   twitterShareUrl,
 } from '../../../templates/socialMediaShareBtns';
-import { baseName, pathInfo, pathUp, sanitizePath } from '../../../utils/files';
+import { baseName, pathInfo, pathUp, sanitizePath, calculateFolderSize } from '../../../utils/files';
 import {
   DEVICE_TYPE,
   FILE_EXPLORER_VIEW_TYPE,
@@ -202,6 +202,7 @@ class FileExplorer extends Component {
         },
       },
       directoryGeneratedTime: Date.now(),
+      folderSizes: {}, // Add state for folder sizes
     };
 
     this.state = {
@@ -258,6 +259,7 @@ class FileExplorer extends Component {
 
     if (nextDirectoryNodes !== prevDirectoryNodes) {
       this._handleDirectoryGeneratedTime();
+      this.calculateFolderSizes(nextDirectoryNodes); // Calculate folder sizes when directory changes
     }
 
     if (nextShowDirectoriesFirst !== showDirectoriesFirst) {
@@ -1985,6 +1987,19 @@ class FileExplorer extends Component {
     });
   };
 
+  calculateFolderSizes = async (nodes) => {
+    const folderSizes = {};
+
+    for (const node of nodes) {
+      if (node.isFolder) {
+        const size = await calculateFolderSize(node.path);
+        folderSizes[node.path] = size;
+      }
+    }
+
+    this.setState({ folderSizes });
+  };
+
   render() {
     const {
       classes: styles,
@@ -1999,7 +2014,7 @@ class FileExplorer extends Component {
       isStatusBarEnabled,
       fileTransferClipboard,
     } = this.props;
-    const { toggleDialog, togglePasteConfirmDialog, directoryGeneratedTime } =
+    const { toggleDialog, togglePasteConfirmDialog, directoryGeneratedTime, folderSizes } =
       this.state;
     const { rename, newFolder } = toggleDialog;
     const togglePasteDialog =
@@ -2181,6 +2196,7 @@ class FileExplorer extends Component {
             this._handleFocussedFileExplorerDeviceType
           }
           onAcceleratorActivation={this._handleAcceleratorActivation}
+          folderSizes={folderSizes} // Pass folder sizes to FileExplorerBodyRender
         />
         ;
       </Fragment>

--- a/app/containers/HomePage/components/FileExplorerTableBodyListRender.jsx
+++ b/app/containers/HomePage/components/FileExplorerTableBodyListRender.jsx
@@ -8,10 +8,10 @@ import classNames from 'classnames';
 import { niceBytes, springTruncate } from '../../../utils/funcs';
 import { FILE_EXPLORER_TABLE_TRUNCATE_MAX_CHARS } from '../../../constants';
 import { styles } from '../styles/FileExplorerTableBodyListRender';
-// eslint-disable-next-line import/no-relative-packages
 import prettyFileIcons from '../../../vendors/pretty-file-icons';
 import { imgsrc } from '../../../utils/imgsrc';
 import { appDateFormat } from '../../../utils/date';
+import { calculateFolderSize } from '../../../utils/files';
 
 class FileExplorerTableBodyListRender extends PureComponent {
   RenderFileIcon = () => {
@@ -56,6 +56,7 @@ class FileExplorerTableBodyListRender extends PureComponent {
       onContextMenuClick,
       onTableClick,
       onTableDoubleClick,
+      folderSizes,
     } = this.props;
 
     const { RenderFileIcon, RenderFolderIcon } = this;
@@ -64,6 +65,8 @@ class FileExplorerTableBodyListRender extends PureComponent {
       item.name,
       FILE_EXPLORER_TABLE_TRUNCATE_MAX_CHARS
     );
+
+    const folderSize = item.isFolder ? folderSizes[item.path] : null;
 
     return (
       <TableRow
@@ -144,7 +147,7 @@ class FileExplorerTableBodyListRender extends PureComponent {
               onTableDoubleClick(item, deviceType, event)
             }
           >
-            {item.isFolder ? `--` : `${niceBytes(item.size)}`}
+            {item.isFolder ? (folderSize ? niceBytes(folderSize) : '--') : `${niceBytes(item.size)}`}
           </TableCell>
         )}
         {hideColList.indexOf('dateAdded') < 0 && (


### PR DESCRIPTION
Related to #349

Add functionality to calculate and display folder sizes in the file explorer.

* **FileExplorer.jsx**
  - Import `calculateFolderSize` from `app/utils/files.js`.
  - Add a function to calculate folder sizes and update state.
  - Update the render method to display folder sizes.

* **FileExplorerTableFooterStatusBarRender.jsx**
  - Import `calculateFolderSize` from `app/utils/files.js`.
  - Add a function to calculate the total size of items in a folder.
  - Update the render method to display the total size of items in a folder.

* **FileExplorerTableBodyListRender.jsx**
  - Import `calculateFolderSize` from `app/utils/files.js`.
  - Add a function to calculate and display folder sizes.
  - Update the render method to display folder sizes.

* **files.js**
  - Add a function `calculateFolderSize` to calculate the size of a folder.

